### PR TITLE
Import improvements & changes to attachment behaviour

### DIFF
--- a/LiquidPro Simple Forms.xml
+++ b/LiquidPro Simple Forms.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="LiquidPro_SimpleForms" title="LiquidPro Simple Forms" version_string="2.1.9d" version_id="21905" url="https://xenforo.com/community/threads/simple-forms-paid-deleted.27945" install_callback_class="LiquidPro_SimpleForms_Version" install_callback_method="Install" uninstall_callback_class="LiquidPro_SimpleForms_Version" uninstall_callback_method="Uninstall">
+<addon addon_id="LiquidPro_SimpleForms" title="LiquidPro Simple Forms" version_string="2.1.9e" version_id="21906" url="https://xenforo.com/community/threads/simple-forms-paid-deleted.27945" install_callback_class="LiquidPro_SimpleForms_Version" install_callback_method="Install" uninstall_callback_class="LiquidPro_SimpleForms_Version" uninstall_callback_method="Uninstall">
   <admin_navigation>
     <navigation navigation_id="createForm" parent_navigation_id="simpleForms" display_order="60" link="forms/add" admin_permission_id="form" debug_only="0" hide_no_children="0"/>
     <navigation navigation_id="displaySimpleForms" parent_navigation_id="simpleForms" display_order="1" link="forms" admin_permission_id="form" debug_only="0" hide_no_children="0"/>

--- a/LiquidPro Simple Forms.xml
+++ b/LiquidPro Simple Forms.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="LiquidPro_SimpleForms" title="LiquidPro Simple Forms" version_string="2.1.9c" version_id="21905" url="https://xenforo.com/community/threads/simple-forms-paid-deleted.27945" install_callback_class="LiquidPro_SimpleForms_Version" install_callback_method="Install" uninstall_callback_class="LiquidPro_SimpleForms_Version" uninstall_callback_method="Uninstall">
+<addon addon_id="LiquidPro_SimpleForms" title="LiquidPro Simple Forms" version_string="2.1.9d" version_id="21905" url="https://xenforo.com/community/threads/simple-forms-paid-deleted.27945" install_callback_class="LiquidPro_SimpleForms_Version" install_callback_method="Install" uninstall_callback_class="LiquidPro_SimpleForms_Version" uninstall_callback_method="Uninstall">
   <admin_navigation>
     <navigation navigation_id="createForm" parent_navigation_id="simpleForms" display_order="60" link="forms/add" admin_permission_id="form" debug_only="0" hide_no_children="0"/>
     <navigation navigation_id="displaySimpleForms" parent_navigation_id="simpleForms" display_order="1" link="forms" admin_permission_id="form" debug_only="0" hide_no_children="0"/>

--- a/LiquidPro Simple Forms.xml
+++ b/LiquidPro Simple Forms.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="LiquidPro_SimpleForms" title="LiquidPro Simple Forms" version_string="2.1.9e" version_id="21906" url="https://xenforo.com/community/threads/simple-forms-paid-deleted.27945" install_callback_class="LiquidPro_SimpleForms_Version" install_callback_method="Install" uninstall_callback_class="LiquidPro_SimpleForms_Version" uninstall_callback_method="Uninstall">
+<addon addon_id="LiquidPro_SimpleForms" title="LiquidPro Simple Forms" version_string="2.1.9f" version_id="21907" url="https://xenforo.com/community/threads/simple-forms-paid-deleted.27945" install_callback_class="LiquidPro_SimpleForms_Version" install_callback_method="Install" uninstall_callback_class="LiquidPro_SimpleForms_Version" uninstall_callback_method="Uninstall">
   <admin_navigation>
     <navigation navigation_id="createForm" parent_navigation_id="simpleForms" display_order="60" link="forms/add" admin_permission_id="form" debug_only="0" hide_no_children="0"/>
     <navigation navigation_id="displaySimpleForms" parent_navigation_id="simpleForms" display_order="1" link="forms" admin_permission_id="form" debug_only="0" hide_no_children="0"/>

--- a/LiquidPro Simple Forms.xml
+++ b/LiquidPro Simple Forms.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="LiquidPro_SimpleForms" title="LiquidPro Simple Forms" version_string="2.1.9b" version_id="21904" url="https://liquidpro.net/xenforo-addons/simple-forms/" install_callback_class="LiquidPro_SimpleForms_Version" install_callback_method="Install" uninstall_callback_class="LiquidPro_SimpleForms_Version" uninstall_callback_method="Uninstall">
+<addon addon_id="LiquidPro_SimpleForms" title="LiquidPro Simple Forms" version_string="2.1.9b" version_id="21905" url="https://liquidpro.net/xenforo-addons/simple-forms/" install_callback_class="LiquidPro_SimpleForms_Version" install_callback_method="Install" uninstall_callback_class="LiquidPro_SimpleForms_Version" uninstall_callback_method="Uninstall">
   <admin_navigation>
     <navigation navigation_id="createForm" parent_navigation_id="simpleForms" display_order="60" link="forms/add" admin_permission_id="form" debug_only="0" hide_no_children="0"/>
     <navigation navigation_id="displaySimpleForms" parent_navigation_id="simpleForms" display_order="1" link="forms" admin_permission_id="form" debug_only="0" hide_no_children="0"/>

--- a/LiquidPro Simple Forms.xml
+++ b/LiquidPro Simple Forms.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="LiquidPro_SimpleForms" title="LiquidPro Simple Forms" version_string="2.1.9b" version_id="21905" url="https://liquidpro.net/xenforo-addons/simple-forms/" install_callback_class="LiquidPro_SimpleForms_Version" install_callback_method="Install" uninstall_callback_class="LiquidPro_SimpleForms_Version" uninstall_callback_method="Uninstall">
+<addon addon_id="LiquidPro_SimpleForms" title="LiquidPro Simple Forms" version_string="2.1.9c" version_id="21905" url="https://xenforo.com/community/threads/simple-forms-paid-deleted.27945" install_callback_class="LiquidPro_SimpleForms_Version" install_callback_method="Install" uninstall_callback_class="LiquidPro_SimpleForms_Version" uninstall_callback_method="Uninstall">
   <admin_navigation>
     <navigation navigation_id="createForm" parent_navigation_id="simpleForms" display_order="60" link="forms/add" admin_permission_id="form" debug_only="0" hide_no_children="0"/>
     <navigation navigation_id="displaySimpleForms" parent_navigation_id="simpleForms" display_order="1" link="forms" admin_permission_id="form" debug_only="0" hide_no_children="0"/>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# xenforo-simple-forms
+# XenForo-SimpleForms
 This is the public github repo for the Simple Forms addon developed formerly by LiquidPro.

--- a/library/LiquidPro/SimpleForms/AttachmentHandler/Form.php
+++ b/library/LiquidPro/SimpleForms/AttachmentHandler/Form.php
@@ -3,6 +3,7 @@
 class LiquidPro_SimpleForms_AttachmentHandler_Form extends XenForo_AttachmentHandler_Abstract
 {
 	protected $_formModel = null;
+	protected $_destinationOptionModel = null;
 
 	/**
 	 * Key of primary content in content data array.
@@ -25,6 +26,7 @@ class LiquidPro_SimpleForms_AttachmentHandler_Form extends XenForo_AttachmentHan
 	 */
 	protected $_contentTypePhraseKey = 'form'	;
 
+	protected $_constraints = null;
 	/**
 	 * Determines if attachments and be uploaded and managed in this context.
 	 *
@@ -32,7 +34,54 @@ class LiquidPro_SimpleForms_AttachmentHandler_Form extends XenForo_AttachmentHan
 	 */
 	protected function _canUploadAndManageAttachments(array $contentData, array $viewingUser)
 	{
-		return true;
+		$this->_constraints = null;
+		$destinationOptionModel = $this->_getDestinationOptionModel();
+		$attachmentTypes = $destinationOptionModel->getAttachmentsDestinationHandlers($contentData['form_id']);
+		if ($attachmentTypes)
+		{
+			foreach($attachmentTypes as $form_destination_id => $row)
+			{
+				$handler_class = $row['handler_class'];
+				if (method_exists($handler_class, 'getAttachmentConstraints'))
+				{
+					$destinationOptions = $destinationOptionModel->getDestinationOptionsByFormDestinationId($form_destination_id);					
+					//$constraints2 =
+					$constraints = call_user_func_array(array($handler_class, 'getAttachmentConstraints'), array($form_destination_id, $destinationOptions));					
+					// make sure all destinations actually support attachments.
+					if (empty($constraints))
+					{
+						return false;
+					}
+					// accept the first constraint
+					if ($this->_constraints === null)
+					{
+						$this->_constraints = $constraints;
+					}
+/*
+					//var_export($constraints2);
+					// merge constraints. Most restrictive wins
+					if ($constraints2['size'] && $constraints2['size'] < $constraints['size'])
+					{
+						$constraints['size'] = $constraints2['size'];
+					}
+					if ($constraints2['count'] && $constraints2['count'] < $constraints['count'])
+					{
+						$constraints['count'] = $constraints2['count'];
+					}
+					if ($constraints2['width'] && $constraints2['width'] < $constraints['width'])
+					{
+						$constraints['width'] = $constraints2['width'];
+					}
+					if ($constraints2['height'] && $constraints2['height'] < $constraints['height'])
+					{
+						$constraints['height'] = $constraints2['height'];
+					}
+*/					
+				}
+			}
+			return true;
+		}
+		return false;
 	}
 	
 	/**
@@ -53,6 +102,28 @@ class LiquidPro_SimpleForms_AttachmentHandler_Form extends XenForo_AttachmentHan
 	public function attachmentPostDelete(array $attachment, Zend_Db_Adapter_Abstract $db)
 	{
 
+	}
+	
+	public function getAttachmentConstraints()
+	{
+		if ($this->_constraints !== null)
+		{
+			return $this->_constraints;
+		}
+		return parent::getAttachmentConstraints();
+	}
+
+	/**
+	 * @return LiquidPro_SimpleForms_Model_Form
+	 */
+	protected function _getDestinationOptionModel()
+	{
+		if (!$this->_destinationOptionModel)
+		{
+			$this->_destinationOptionModel = XenForo_Model::create('LiquidPro_SimpleForms_Model_DestinationOption');
+		}
+
+		return $this->_destinationOptionModel;
 	}
 
 	/**

--- a/library/LiquidPro/SimpleForms/DataWriter/Field.php
+++ b/library/LiquidPro/SimpleForms/DataWriter/Field.php
@@ -329,10 +329,10 @@ class LiquidPro_SimpleForms_DataWriter_Field extends XenForo_DataWriter
 	
 		$this->setFieldChoices(unserialize((string)$field['field_choices']));
 
+		$this->save();
+
 		// imported forms are never global, so just update the phrase(s)
 		$this->updatePhrases();
-
-		$this->save();		
 	}
 	
 	/**

--- a/library/LiquidPro/SimpleForms/DataWriter/Field.php
+++ b/library/LiquidPro/SimpleForms/DataWriter/Field.php
@@ -290,6 +290,8 @@ class LiquidPro_SimpleForms_DataWriter_Field extends XenForo_DataWriter
 	
 	public function setFieldXml($field, $formId)
 	{
+		$this->setImportMode(true);
+
 		$fieldData = array(
 			'form_id' => $formId,
 			'type' => 'user',
@@ -326,7 +328,10 @@ class LiquidPro_SimpleForms_DataWriter_Field extends XenForo_DataWriter
 		);
 	
 		$this->setFieldChoices(unserialize((string)$field['field_choices']));
-			
+
+		// imported forms are never global, so just update the phrase(s)
+		$this->updatePhrases();
+
 		$this->save();		
 	}
 	

--- a/library/LiquidPro/SimpleForms/DataWriter/Form.php
+++ b/library/LiquidPro/SimpleForms/DataWriter/Form.php
@@ -78,19 +78,28 @@ class LiquidPro_SimpleForms_DataWriter_Form extends XenForo_DataWriter
 	
 	protected function _postSave()
 	{
-		$this->getModelFromCache('XenForo_Model_Permission')->rebuildPermissionCache();
-		
-		// insert a dummy page
-		$pageDw = XenForo_DataWriter::create('LiquidPro_SimpleForms_DataWriter_Page');
-		$pageDw->bulkSet(array(
-		    'form_id' => $this->get('form_id'),
-		    'page_number' => 1,
-		    'title' => '',
-		    'description' => ''
-		));
-		$pageDw->save();
-		
+		if ($this->isInsert())
+		{
+			// insert a dummy page
+			$pageDw = XenForo_DataWriter::create('LiquidPro_SimpleForms_DataWriter_Page');
+			$pageDw->bulkSet(array(
+				'form_id' => $this->get('form_id'),
+				'page_number' => 1,
+				'title' => '',
+				'description' => ''
+			));
+			$pageDw->save();
+		}
+
 		parent::_postSave();
+	}
+
+	protected function _postSaveAfterTransaction()
+	{
+		if ($this->isInsert())
+		{
+			$this->getModelFromCache('XenForo_Model_Permission')->rebuildPermissionCache();
+		}
 	}
 	
 	/**

--- a/library/LiquidPro/SimpleForms/DataWriter/FormDestination.php
+++ b/library/LiquidPro/SimpleForms/DataWriter/FormDestination.php
@@ -89,11 +89,17 @@ class LiquidPro_SimpleForms_DataWriter_FormDestination extends XenForo_DataWrite
 	{
 		$this->updateDestinationOptions();
 	
-		$this->getModelFromCache('XenForo_Model_Permission')->rebuildPermissionCache();
-	
 		parent::_postSave();
 	}	
-	
+
+	protected function _postSaveAfterTransaction()
+	{
+		if ($this->isInsert())
+		{
+			$this->getModelFromCache('XenForo_Model_Permission')->rebuildPermissionCache();
+		}
+	}
+
 	public function setDestinationOptions(array $destinationOptionValues, array $optionsShown = null)
 	{
 		$destinationModel = $this->_getDestinationModel();
@@ -210,6 +216,8 @@ class LiquidPro_SimpleForms_DataWriter_FormDestination extends XenForo_DataWrite
 	
 	public function setFormDestinationXml($formDestination, $formId)
 	{
+		$this->setImportMode(true);
+
 		$formDestinationData = array(
 			'destination_id' => (int)$formDestination['destination_id'],
 			'form_id' => $formId,

--- a/library/LiquidPro/SimpleForms/DataWriter/Response.php
+++ b/library/LiquidPro/SimpleForms/DataWriter/Response.php
@@ -146,7 +146,7 @@ class LiquidPro_SimpleForms_DataWriter_Response extends XenForo_DataWriter
 					$formDestination = new $destination['handler_class']($form['form_id'], $this->_updateFields, $destinationOptions, null, $this->get('response_id'));
 
 					// handle attachments
-					if ($destinationOptionModel->getAttachmentsEnabled($form['form_id']) && $attachments)
+					if ($destinationOptionModel->getAttachmentsDestinationHandlers($form['form_id']) && $attachments)
 					{
 						// create new temporary hash
 						$newAttachmentHash = md5(uniqid('', true));

--- a/library/LiquidPro/SimpleForms/Destination/Abstract.php
+++ b/library/LiquidPro/SimpleForms/Destination/Abstract.php
@@ -224,4 +224,23 @@ abstract class LiquidPro_SimpleForms_Destination_Abstract
 	    $newString = '[ATTACH]' . $this->_attachmentId . '[/ATTACH]';
 	    $field = str_replace($oldString, $newString, $field);
 	}
+
+	static $attachmentModel = null;
+	public static function _getAttachmentConstraints($contentType, $contentData)
+	{
+		if (self::$attachmentModel === null)
+		{
+			self::$attachmentModel = XenForo_Model::create('XenForo_Model_Attachment');
+		}
+
+		$attachmentHandler = self::$attachmentModel->getAttachmentHandler($contentType);
+
+		if (!$attachmentHandler || !$attachmentHandler->canUploadAndManageAttachments($contentData))
+		{
+			XenForo_Error::debug('form_destination_id '.$form_destination_id .' does not accept attachments for the user '. XenForo_Visitor::getUserId());
+			throw new XenForo_Exception(new XenForo_Phrase('attachment_cannot_be_shown_at_this_time'), true);
+		}
+
+		return $attachmentHandler->getAttachmentConstraints();
+	}
 }

--- a/library/LiquidPro/SimpleForms/Destination/Abstract.php
+++ b/library/LiquidPro/SimpleForms/Destination/Abstract.php
@@ -226,7 +226,7 @@ abstract class LiquidPro_SimpleForms_Destination_Abstract
 	}
 
 	static $attachmentModel = null;
-	public static function _getAttachmentConstraints($contentType, $contentData)
+	public static function _getAttachmentConstraints($form_destination_id, $contentType, $contentData)
 	{
 		if (self::$attachmentModel === null)
 		{

--- a/library/LiquidPro/SimpleForms/Destination/Conversation.php
+++ b/library/LiquidPro/SimpleForms/Destination/Conversation.php
@@ -157,7 +157,7 @@ class LiquidPro_SimpleForms_Destination_Conversation extends LiquidPro_SimpleFor
 	public static function getAttachmentConstraints($form_destination_id, $destinationOptions)
 	{
 		$contentData = array();
-		return self::_getAttachmentConstraints('conversation_message', $contentData);
+		return self::_getAttachmentConstraints($form_destination_id, 'conversation_message', $contentData);
 	}
 	
 	/**

--- a/library/LiquidPro/SimpleForms/Destination/Conversation.php
+++ b/library/LiquidPro/SimpleForms/Destination/Conversation.php
@@ -153,6 +153,12 @@ class LiquidPro_SimpleForms_Destination_Conversation extends LiquidPro_SimpleFor
 		
 		return $errors;
 	}
+
+	public static function getAttachmentConstraints($form_destination_id, $destinationOptions)
+	{
+		$contentData = array();
+		return self::_getAttachmentConstraints('conversation_message', $contentData);
+	}
 	
 	/**
 	 * @return XenForo_Model_Conversation

--- a/library/LiquidPro/SimpleForms/Destination/Thread.php
+++ b/library/LiquidPro/SimpleForms/Destination/Thread.php
@@ -287,7 +287,18 @@ class LiquidPro_SimpleForms_Destination_Thread extends LiquidPro_SimpleForms_Des
 		
 		return $errors;
 	}
-	
+
+	public static function getAttachmentConstraints($form_destination_id, $destinationOptions)
+	{
+		if (empty($destinationOptions['thread_forum_node_id']['option_value']))
+		{
+			return array();
+		}
+
+		$contentData = array('node_id' => $destinationOptions['thread_forum_node_id']['option_value']);
+		return self::_getAttachmentConstraints('post', $contentData);
+	}
+
 	/**
 	 * @return XenForo_Model_Forum
 	 */

--- a/library/LiquidPro/SimpleForms/Destination/Thread.php
+++ b/library/LiquidPro/SimpleForms/Destination/Thread.php
@@ -296,7 +296,7 @@ class LiquidPro_SimpleForms_Destination_Thread extends LiquidPro_SimpleForms_Des
 		}
 
 		$contentData = array('node_id' => $destinationOptions['thread_forum_node_id']['option_value']);
-		return self::_getAttachmentConstraints('post', $contentData);
+		return self::_getAttachmentConstraints($form_destination_id, 'post', $contentData);
 	}
 
 	/**

--- a/library/LiquidPro/SimpleForms/Install/20.php
+++ b/library/LiquidPro/SimpleForms/Install/20.php
@@ -20,22 +20,6 @@ class LiquidPro_SimpleForms_Install_20 extends LiquidPro_SimpleForms_Install_Abs
 			$db->query("ALTER TABLE `" . $foreignKey['TABLE_NAME'] . "` DROP FOREIGN KEY `" . $foreignKey['CONSTRAINT_NAME'] . "`");
 		}
 		
-		// get a list of tables that are InnoDB
-		$tables = $db->fetchAll('
-			SELECT
-				*
-			FROM `INFORMATION_SCHEMA`.`TABLES`
-			WHERE `TABLE_SCHEMA` = DATABASE()
-				AND `TABLE_NAME` LIKE \'lpsf_%\'	
-				AND `ENGINE` = \'InnoDB\'
-		');
-		
-		// convert InnoDB tables to MyISAM
-		foreach ($tables as $table)
-		{
-			$db->query("ALTER TABLE `" . $table['TABLE_NAME'] . "` ENGINE = 'MyISAM'");
-		}
-		
 		$table = $this->describeTable('lpsf_field');
 		
 		// check to see if placeholder exists

--- a/library/LiquidPro/SimpleForms/Install/21600.php
+++ b/library/LiquidPro/SimpleForms/Install/21600.php
@@ -13,7 +13,7 @@ class LiquidPro_SimpleForms_Install_21600 extends LiquidPro_SimpleForms_Install_
               `title` varchar(50) NOT NULL,
               `description` mediumtext,
 			  PRIMARY KEY (`page_id`)
-			) ENGINE=MyISAM  DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
+			) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
 		");
         
         // populate each form with a single page

--- a/library/LiquidPro/SimpleForms/Install/21905.php
+++ b/library/LiquidPro/SimpleForms/Install/21905.php
@@ -1,0 +1,25 @@
+<?php
+
+class LiquidPro_SimpleForms_Install_21902 extends LiquidPro_SimpleForms_Install_Abstract
+{
+    public function install(&$db)
+    {
+		// get a list of tables that are MyISAM
+		$tables = $db->fetchAll('
+			SELECT
+				*
+			FROM `INFORMATION_SCHEMA`.`TABLES`
+			WHERE `TABLE_SCHEMA` = DATABASE()
+				AND `TABLE_NAME` LIKE \'lpsf_%\'
+				AND `ENGINE` = \'MyISAM\'
+		');
+
+		// convert MyISAM tables to InnoDB
+		foreach ($tables as $table)
+		{
+			$db->query("ALTER TABLE `" . $table['TABLE_NAME'] . "` ENGINE = 'InnoDB'");
+		}
+
+        return true;
+    }
+}

--- a/library/LiquidPro/SimpleForms/Install/21905.php
+++ b/library/LiquidPro/SimpleForms/Install/21905.php
@@ -1,6 +1,6 @@
 <?php
 
-class LiquidPro_SimpleForms_Install_21902 extends LiquidPro_SimpleForms_Install_Abstract
+class LiquidPro_SimpleForms_Install_21905 extends LiquidPro_SimpleForms_Install_Abstract
 {
     public function install(&$db)
     {

--- a/library/LiquidPro/SimpleForms/Model/DestinationOption.php
+++ b/library/LiquidPro/SimpleForms/Model/DestinationOption.php
@@ -60,25 +60,34 @@ class LiquidPro_SimpleForms_Model_DestinationOption extends XenForo_Model
 		'option_id', $formDestinationId);
 	}
 	
-	public function getAttachmentsEnabled($formId)
+	public function getAttachmentsDestinationHandlers($formId)
 	{
-	    $result = $this->_getDb()->fetchOne('
-            SELECT option_value
+	    $destinations = $this->_getDb()->fetchAll('
+            SELECT option_value, lpsf_form_destination.form_destination_id, lpsf_destination.handler_class
             FROM lpsf_form_destination
             JOIN lpsf_form_destination_option
               ON lpsf_form_destination_option.form_destination_id = lpsf_form_destination.form_destination_id
+			JOIN lpsf_destination on lpsf_destination.destination_id = lpsf_form_destination.destination_id
             WHERE option_id LIKE \'%_enable_attachments\' 
-              AND form_id = ?	            
+              AND form_id = ?
 	    ', $formId);
-	    
-	    if ($result && unserialize($result) !== array())
-	    {
-	        return true;
-	    }
-	    else
-	    {
-	        return false;
-	    }
+		if (empty($destinations))
+		{
+			return false;
+		}
+
+		$contentTypes = array();
+
+		foreach($destinations as $destination)
+		{
+			$result = @unserialize($destination['option_value']);
+			if ($result !== array() && !isset($contentTypes[$destination['form_destination_id']]))
+			{
+				$contentTypes[$destination['form_destination_id']] = $destination;
+			}
+		}
+
+	    return $contentTypes;
 	}
 
 	/**


### PR DESCRIPTION
- Improvements for form importer (drastic memory usage reduction for lots of phrases or permission sets)
- Use MyISAM tables rather than InnoDB (works with transactions instead of ignoring them, crash resistant, etc)
- Rebuild attachment handling so the destination is attributes are respected. More work is required as this requires the 'can attach' permission for the form to work. Only handles the first destination which allows attachments.
